### PR TITLE
Implemented a semaphore to avoid racing condition

### DIFF
--- a/Sparkfly.Main/Components/TrackCard.razor
+++ b/Sparkfly.Main/Components/TrackCard.razor
@@ -43,7 +43,4 @@
     [Parameter] public EventCallback<Track> OnClickCallback { get; set; }
 
     private async Task OnButtonClick() => await OnClickCallback.InvokeAsync(Track);
-
-    //private async Task EnqueueVoteAsync() => await Sparkfly.EnqueueVoteAsync(Track);
-    //private async Task RemoveVoteAsync() => await Sparkfly.RemoveVoteAsync(Track);
 }

--- a/Sparkfly.Main/Pages/CurrentlyPlayingPage.razor
+++ b/Sparkfly.Main/Pages/CurrentlyPlayingPage.razor
@@ -52,6 +52,8 @@
 
     private async void UpdateUi(object source, EventArgs args)
     {
+        await Sparkfly.WaitTimerAsync();
+
         Track newestTrack = await Sparkfly.GetCurrentlyPlayingAsync();
 
         Vote? votes = (await Sparkfly.PeekVotingQueue());

--- a/Sparkfly.Main/Pages/QueuePage.razor
+++ b/Sparkfly.Main/Pages/QueuePage.razor
@@ -23,7 +23,6 @@
             }
         }
     }
-
 </MudStack>
 
 @code {
@@ -35,6 +34,5 @@
     {
         await Sparkfly.RemoveVoteAsync(track);
         votes = await Sparkfly.GetVotingQueueAsync();
-        await InvokeAsync(StateHasChanged);     // NOTE: may not be necessary... see Blazor EventCallback with parameters
     }
 }


### PR DESCRIPTION
Implemented a semaphore to avoid racing condition when loading local storage.

The reason for the hotfix was that it was taking too long (twice as much) to update the Currently Playing page. Actually, it was being updated regularly according to the Timer, but because of racing condition, the refreshed UI looked exactly the same. Even though the data structures were already updated.