### PR TITLE
Fixed issue after connection was lost

### DIFF
--- a/Sparkfly.Main/Pages/PartyPage.razor
+++ b/Sparkfly.Main/Pages/PartyPage.razor
@@ -3,7 +3,7 @@
 @using Sparkfly.Main.Services
 
 @inject SparkflyManager Sparkfly
-@inject ProtectedSessionStorage ProtectedSession
+@inject ProtectedLocalStorage LocalStorage
 
 <MudStack>
     <h3>Share the Party Code!</h3>
@@ -20,12 +20,12 @@
 
     private async Task SetClientNameAsync()
     {
-        Client? thisClient = (await ProtectedSession.GetAsync<Client>("this_client")).Value;
+        Client? thisClient = (await LocalStorage.GetAsync<Client>("this_client")).Value;
 
         if (thisClient is not null && _clientNameInput is not null)
         {
             thisClient.Name = _clientNameInput;
-            await ProtectedSession.SetAsync("this_client", thisClient);
+            await LocalStorage.SetAsync("this_client", thisClient);
 
             Sparkfly.UpdateClient(thisClient);
         }

--- a/Sparkfly.Main/Pages/QueuePage.razor
+++ b/Sparkfly.Main/Pages/QueuePage.razor
@@ -4,7 +4,7 @@
 @using Sparkfly.Main.Services
 
 @inject SparkflyManager Sparkfly
-@inject ProtectedSessionStorage ProtectedSession
+@inject ProtectedLocalStorage LocalStorage
 
 <MudStack>
     <MudText Align="Align.Center" Typo="Typo.h5">Priority Queues</MudText>
@@ -35,7 +35,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _thisClient = (await ProtectedSession.GetAsync<Client>("this_client")).Value;
+        _thisClient = (await LocalStorage.GetAsync<Client>("this_client")).Value;
 
         Sparkfly.TimerUpdateEvent += UpdateUi;
         Sparkfly.VotingQueueUpdateEvent += UpdateUi;

--- a/Sparkfly.Main/Pages/SearchPage.razor
+++ b/Sparkfly.Main/Pages/SearchPage.razor
@@ -7,7 +7,7 @@
 
 @inject SparkflyManager Sparkfly
 @inject NavigationManager NavManager
-@inject ProtectedSessionStorage ProtectedSession
+@inject ProtectedLocalStorage LocalStorage
 
 <MudStack Class="d-flex flex-column flex-grow-1 gap-4">
     <form @onsubmit="SearchTracks">
@@ -37,7 +37,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _thisClient = (await ProtectedSession.GetAsync<Client>("this_client")).Value;
+        _thisClient = (await LocalStorage.GetAsync<Client>("this_client")).Value;
     }
 
     private void EnqueueVote(Track track)

--- a/Sparkfly.Main/Pages/ValidatePartyPage.razor
+++ b/Sparkfly.Main/Pages/ValidatePartyPage.razor
@@ -7,7 +7,7 @@
 
 @inject SparkflyManager Sparkfly
 @inject NavigationManager NavManager
-@inject ProtectedSessionStorage ProtectedSession
+@inject ProtectedLocalStorage LocalStorage
 
 @code {
     [Parameter]
@@ -34,9 +34,9 @@
             {
                 try
                 {
-                    await Sparkfly.SpotifyRequestTokensAsync(Code, (await ProtectedSession.GetAsync<string>("state")).Value ?? string.Empty, State);
+                    await Sparkfly.SpotifyRequestTokensAsync(Code, (await LocalStorage.GetAsync<string>("state")).Value ?? string.Empty, State);
 
-                    await ProtectedSession.DeleteAsync("state");
+                    await LocalStorage.DeleteAsync("state");
 
                     Sparkfly.StartTimer();
                 }
@@ -51,7 +51,7 @@
 
             Client newClient = new Client(Guid.NewGuid().ToString(), null);
             Sparkfly.Clients.Add(newClient);
-            await ProtectedSession.SetAsync("this_client", newClient);
+            await LocalStorage.SetAsync("this_client", newClient);
 
             NavManager.NavigateTo("/party");
         }

--- a/Sparkfly.Main/Pages/WelcomePage.razor
+++ b/Sparkfly.Main/Pages/WelcomePage.razor
@@ -5,7 +5,7 @@
 
 @inject SparkflyManager Sparkfly
 @inject NavigationManager NavManager
-@inject ProtectedSessionStorage ProtectedSession
+@inject ProtectedLocalStorage LocalStorage
 
 <PageTitle>Welcome to Sparkfly!</PageTitle>
 
@@ -26,7 +26,7 @@
     private void SpotifySignIn() 
     {
         string state = new Random().Next().ToString();
-        ProtectedSession.SetAsync("state", state);
+        LocalStorage.SetAsync("state", state);
 
         try
         {

--- a/Sparkfly.Main/_Imports.razor
+++ b/Sparkfly.Main/_Imports.razor
@@ -13,4 +13,3 @@
 @using static Sparkfly.Main.Data.Track
 @using Sparkfly.Main.Data
 @using System.Net;
-@inject ProtectedSessionStorage ProtectedSessionStore


### PR DESCRIPTION
Fixed a problem with data not persisting after a page reload when the connection was lost.

This basically ensures that when the user is using the mobile version, after they switch to another app, or locks the phone, and comeback to Sparkfly, the user information must remain intact.